### PR TITLE
A few readability suggestions

### DIFF
--- a/extension/howdoi/.eslintrc
+++ b/extension/howdoi/.eslintrc
@@ -23,12 +23,14 @@
         "flatTernaryExpressions": false,
         "ignoreComments": false
       }
-    ],        
+    ],
     "@typescript-eslint/class-name-casing": "warn",
-    "@typescript-eslint/semi": "warn",
+    "@typescript-eslint/semi": "off",
+    "comma-spacing": ["error", { "before": false, "after": true }],
     "curly": "warn",
     "eqeqeq": "warn",
     "no-throw-literal": "warn",
+    "quotes": ["error", "single"],
     "semi": "off"
   }
 }

--- a/extension/howdoi/package.json
+++ b/extension/howdoi/package.json
@@ -13,12 +13,12 @@
     "onCommand:howdoi.extension"
   ],
   "main": "./out/extension.js",
-    "contributes": {
-      "commands": [
-        {
-          "command": "howdoi.extension",
-          "title": "howdoi"
-        }
+  "contributes": {
+    "commands": [
+      {
+        "command": "howdoi.extension",
+        "title": "howdoi"
+      }
     ]
   },
   "scripts": {

--- a/extension/howdoi/src/extension.ts
+++ b/extension/howdoi/src/extension.ts
@@ -1,158 +1,158 @@
-import * as vscode from 'vscode';
-import * as cp from "child_process";
+import * as vscode from 'vscode'
+import * as cp from 'child_process'
 
-const HOWDOI_PREFIX = 'howdoi';
+const HOWDOI_PREFIX = 'howdoi'
 
 interface HowdoiResult {
-    question: string;
-    answer: string[];
-    link: string[];   
+    question: string
+    answer: string[]
+    link: string[]
 }
 
-async function spawnChild(command:string, callback:any) {
-  const commandWithoutPrefix = removeHowdoiPrefix(command);
-  const process = await cp.spawn("howdoi", [commandWithoutPrefix, '-n 3']);
-  let howdoiCommandOutput:string = '';
-	
-  process.stdout.on("data", (data:any) => {
-    howdoiCommandOutput += String(data);
-  });	
-	
-  process.stderr.on("data", (data:any) => {
-    console.log(`stderr: ${data}`);
-  });
-		
-  process.on('error', (error:any) => {
-    console.log(`error: ${error.message}`);
-  });
-		
-  process.on("close", (code:any) => {
-    console.log(`child process exited with code ${code}`);
-    return callback(howdoiCommandOutput);
-  });
+async function spawnChild(command: string, callback: any) {
+  const commandWithoutPrefix = removeHowdoiPrefix(command)
+  const process = await cp.spawn('howdoi', [commandWithoutPrefix, '-n 3'])
+  let howdoiCommandOutput: string = ''
+
+  process.stdout.on('data', (data: any) => {
+    howdoiCommandOutput += String(data)
+  })
+
+  process.stderr.on('data', (data: any) => {
+    console.log(`stderr: ${data}`)
+  })
+
+  process.on('error', (error: any) => {
+    console.log(`error: ${error.message}`)
+  })
+
+  process.on('close', (code: any) => {
+    console.log(`child process exited with code ${code}`)
+    return callback(howdoiCommandOutput)
+  })
 }
 
-function removeHowdoiPrefix(command:string): string {
+function removeHowdoiPrefix(command: string): string {
   if (!command.trim().startsWith(HOWDOI_PREFIX)) {
-    return command;
+    return command
   }
-  return command.replace(HOWDOI_PREFIX, '');
+  return command.replace(HOWDOI_PREFIX, '')
 }
 
-function modifyCommentedText(userCommand:string): string[]|null {
-  /* This function finds the comment regex, removes it from the string and returns an array 
+function modifyCommentedText(userCommand: string): string[]|null {
+  /* This function finds the comment regex, removes it from the string and returns an array
   with the modified string, the beginning comment regex, ending comment regex */
-  const frontCommentRegex =  /^[!@#<>/\$%\^\&*\)\(+=._-]+/;
-  const endCommentRegex = /[!@#<>/\$%\^\&*\)\(+=._-]+$/;
-  let frontCommentChar:string;
-  let endCommentChar:string;	
-  let userCommandWithoutComment:string[];
-  const initialMatchRegex:RegExpMatchArray | null = userCommand.match(frontCommentRegex);
-  const endMatchRegex:RegExpMatchArray | null = userCommand.match(frontCommentRegex);
-        
+  const frontCommentRegex = /^[!@#<>/\$%\^\&*\)\(+=._-]+/
+  const endCommentRegex = /[!@#<>/\$%\^\&*\)\(+=._-]+$/
+  let frontCommentChar: string
+  let endCommentChar: string
+  let userCommandWithoutComment: string[]
+  const initialMatchRegex: RegExpMatchArray | null = userCommand.match(frontCommentRegex)
+  const endMatchRegex: RegExpMatchArray | null = userCommand.match(frontCommentRegex)
+
   if (initialMatchRegex && endMatchRegex){
-    frontCommentChar = initialMatchRegex.join();
-    endCommentChar = endMatchRegex.join();
-    userCommand = userCommand.replace(frontCommentRegex, '');
-    userCommand = userCommand.replace(endCommentRegex, '');
-    userCommandWithoutComment = [userCommand, frontCommentChar, endCommentChar];
-    return userCommandWithoutComment;
+    frontCommentChar = initialMatchRegex.join()
+    endCommentChar = endMatchRegex.join()
+    userCommand = userCommand.replace(frontCommentRegex, '')
+    userCommand = userCommand.replace(endCommentRegex, '')
+    userCommandWithoutComment = [userCommand, frontCommentChar, endCommentChar]
+    return userCommandWithoutComment
   }
   else if(endMatchRegex){
-    endCommentChar = endMatchRegex.join();
-    userCommand = userCommand.replace(endCommentRegex, '');
-    userCommandWithoutComment = [userCommand,'',endCommentChar];
-    return userCommandWithoutComment;
+    endCommentChar = endMatchRegex.join()
+    userCommand = userCommand.replace(endCommentRegex, '')
+    userCommandWithoutComment = [userCommand, '', endCommentChar]
+    return userCommandWithoutComment
   }
   else if(initialMatchRegex){
-    frontCommentChar = initialMatchRegex.join();
-    userCommand= userCommand.replace(frontCommentRegex, '');
-    userCommandWithoutComment = [userCommand, frontCommentChar, ''];
-    return userCommandWithoutComment;
+    frontCommentChar = initialMatchRegex.join()
+    userCommand= userCommand.replace(frontCommentRegex, '')
+    userCommandWithoutComment = [userCommand, frontCommentChar, '']
+    return userCommandWithoutComment
   }
   else {
-    return null;
+    return null
   }
 }
 
-function organizeHowdoiOutput(howdoiOutput:string, frontCommentChar:string, endCommentChar:string): string[][] {
-  /* Creates an array from the howdoiOutput string in which each element 
+function organizeHowdoiOutput(howdoiOutput: string, frontCommentChar: string, endCommentChar: string): string[][] {
+  /* Creates an array from the howdoiOutput string in which each element
   is one of three answers from the usersCommand */
-  const delim:string = '\n'+'================================================================================'+'\n'+'\n';
-  const howdoiAnswersArr:string[] = howdoiOutput.split(delim);
+  const delim: string = '\n'+'================================================================================'+'\n'+'\n'
+  const howdoiAnswersArr: string[] = howdoiOutput.split(delim)
   /* Creates a 2D array from howdoiAnswersArr in which each element is an array which denotes
   one of three answers from the usersCommand, and the elements in that array are the link and answer */
-  let newHowdoiAnswersArr:string[][] = howdoiAnswersArr.map((elem) => elem.split(' ★'));
-  //  The comment Regex is added to the link string
+  let newHowdoiAnswersArr: string[][] = howdoiAnswersArr.map((elem) => elem.split(' ★'))
+  // The comment Regex is added to the link string
   for (let i = 0; i < newHowdoiAnswersArr.length; i++) {
-    newHowdoiAnswersArr[i][0] = frontCommentChar + newHowdoiAnswersArr[i][0] + endCommentChar;
+    newHowdoiAnswersArr[i][0] = frontCommentChar + newHowdoiAnswersArr[i][0] + endCommentChar
   }
-  return newHowdoiAnswersArr;
+  return newHowdoiAnswersArr
 }
 
-function createHowdoiResult(howdoiResultArr:string[][], userCommand:string): HowdoiResult {
-  let howdoiResultObj:HowdoiResult = {question: userCommand, answer: [], link: []};
-	
+function createHowdoiResult(howdoiResultArr: string[][], userCommand: string): HowdoiResult {
+  let howdoiResultObj: HowdoiResult = {question: userCommand, answer: [], link: []}
+
   for (let i = 0; i < howdoiResultArr.length; i++) {
-    howdoiResultObj.link.push(howdoiResultArr[i][0]);
-    howdoiResultObj.answer.push(howdoiResultArr[i][1]);
+    howdoiResultObj.link.push(howdoiResultArr[i][0])
+    howdoiResultObj.answer.push(howdoiResultArr[i][1])
   }
-	
-  return howdoiResultObj;
+
+  return howdoiResultObj
 }
 
-function howdoi(howdoiOutput:string, userCommand:string, frontCommentChar:string, endCommentChar:string): HowdoiResult {
-  const organizedHowdoiArr:string[][] = organizeHowdoiOutput(howdoiOutput, frontCommentChar, endCommentChar);
-  const howdoiResultObj:HowdoiResult = createHowdoiResult(organizedHowdoiArr, userCommand);
-  return howdoiResultObj;
+function howdoi(howdoiOutput: string, userCommand: string, frontCommentChar: string, endCommentChar: string): HowdoiResult {
+  const organizedHowdoiArr: string[][] = organizeHowdoiOutput(howdoiOutput, frontCommentChar, endCommentChar)
+  const howdoiResultObj: HowdoiResult = createHowdoiResult(organizedHowdoiArr, userCommand)
+  return howdoiResultObj
 }
- 
-function quickPicker(editor:any, howdoiResultObj:HowdoiResult, userCommand:string): void {
-  const quickPick = vscode.window.createQuickPick();
-		
-  quickPick.items = howdoiResultObj.answer.map((answer:any) => (
-    {label: answer, link:  howdoiResultObj.link[howdoiResultObj.answer.indexOf(answer)] }));
-	
-  quickPick.onDidChangeSelection(([item]:any) => {
+
+function quickPicker(editor: any, howdoiResultObj: HowdoiResult, userCommand: string): void {
+  const quickPick = vscode.window.createQuickPick()
+
+  quickPick.items = howdoiResultObj.answer.map((answer: any) => (
+    {label: answer, link: howdoiResultObj.link[howdoiResultObj.answer.indexOf(answer)] }))
+
+  quickPick.onDidChangeSelection(([item]: any) => {
     if (item) {
-      editor.edit((edit:any) => {
-        edit.replace(editor.selection, userCommand + '\n' + item.link + item.label);	
-      });	
-	  quickPick.dispose();
+      editor.edit((edit: any) => {
+        edit.replace(editor.selection, userCommand + '\n' + item.link + item.label)
+      })
+	  quickPick.dispose()
     }
-  });
-  quickPick.onDidHide(() => quickPick.dispose());
-  quickPick.show();	
+  })
+  quickPick.onDidHide(() => quickPick.dispose())
+  quickPick.show()
 }
 
 export function activate(context: vscode.ExtensionContext) {
 
   let disposable = vscode.commands.registerCommand('howdoi.extension', () => {
-		
-    const editor = vscode.window.activeTextEditor;
+
+    const editor = vscode.window.activeTextEditor
     if (!editor) {
-      vscode.window.showInformationMessage('create a file to enable howdoi');
-      return;
+      vscode.window.showInformationMessage('create a file to enable howdoi')
+      return
     }
 
-    const userCommand:string = editor.document.getText(editor.selection);
-    const userCommandWithoutComment:string[]|null = modifyCommentedText(userCommand);
+    const userCommand: string = editor.document.getText(editor.selection)
+    const userCommandWithoutComment: string[]|null = modifyCommentedText(userCommand)
 
     if (userCommandWithoutComment !== null) {
-      const textToBeSearched:string = userCommandWithoutComment[0];
-      const frontCommentChar:string  = userCommandWithoutComment[1];
-      const endCommentChar:string = userCommandWithoutComment[2];
+      const textToBeSearched: string = userCommandWithoutComment[0]
+      const frontCommentChar: string  = userCommandWithoutComment[1]
+      const endCommentChar: string = userCommandWithoutComment[2]
 
-      spawnChild(textToBeSearched, function(howdoiOutput:string) {
-        let howdoiResultObj = howdoi(howdoiOutput, userCommand, frontCommentChar, endCommentChar);
-        quickPicker(editor, howdoiResultObj, userCommand);	
-      });
+      spawnChild(textToBeSearched, function(howdoiOutput: string) {
+        let howdoiResultObj = howdoi(howdoiOutput, userCommand, frontCommentChar, endCommentChar)
+        quickPicker(editor, howdoiResultObj, userCommand)
+      })
     }
     else {
-      vscode.window.showErrorMessage('please use single line comment for howdoi.');
+      vscode.window.showErrorMessage('please use single line comment for howdoi.')
     }
-  });
-  context.subscriptions.push(disposable);
+  })
+  context.subscriptions.push(disposable)
 }
 
 export function deactivate() {}

--- a/extension/howdoi/src/test/runTest.ts
+++ b/extension/howdoi/src/test/runTest.ts
@@ -15,8 +15,8 @@ async function main() {
     // Download VS Code, unzip it and run the integration test
     await runTests({ extensionDevelopmentPath, extensionTestsPath });
   } catch (err) {
-      console.error('Failed to run tests');
-      process.exit(1);
+    console.error('Failed to run tests');
+    process.exit(1);
   }
 }
 

--- a/extension/howdoi/src/test/suite/index.ts
+++ b/extension/howdoi/src/test/suite/index.ts
@@ -20,19 +20,19 @@ export function run(): Promise<void> {
       // Add files to the test suite
       files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
 
-	  try {
+      try {
         // Run the mocha test
         mocha.run(failures => {
           if (failures > 0) {
             e(new Error(`${failures} tests failed.`));
-            } else {
-              c();
-            }
+          } else {
+            c();
+          }
         });
       } catch (err) {
-		  console.error(err);
-		  e(err);
-        } 
+        console.error(err);
+        e(err);
+      }
     });
   });
 }


### PR DESCRIPTION
- Add a space after variable and before typescript types (`foo:HowdoiResult` -> `foo:
HowdoiResult`)
- Remove all semicolons (It's weird, I know, but they aren't necessary
in Typescript. I also changed the `.eslintrc` file to show errors if
semicolons are included)
- Prefer using `'` everywhere rather than `"` (added eslint rule)
- Make sure that there is always a space after a comma (added eslint
rule)
- Fix indentation according to lint suggestions

Some of these changes are personal preference, but by attaching an
associated eslint rule and requiring that linting pass before a PR can
be accepted, you can keep the codebase readable and uniform.